### PR TITLE
fix: use `mktemp -d -t` on macOS

### DIFF
--- a/frendetta.sh
+++ b/frendetta.sh
@@ -5,7 +5,15 @@
 # specify $ANDROID_SERIAL to install to a specific device
 # i'm making an actual patcher app in the future so neither a pc or adb will be required
 
-DATA=$(mktemp --directory --tmpdir "frendetta.XXXXXXXX")
+OS=$(uname)
+case $OS in
+  'Darwin')
+    DATA=$(mktemp -d -t "frendetta.XXXXXXXX")
+    ;;
+  *)
+    DATA=$(mktemp --directory --tmpdir "frendetta.XXXXXXXX")
+    ;;
+esac
 
 exec > >(tee "$DATA/frendetta.log") 2>&1
 


### PR DESCRIPTION
macOS doesn't have support for the fully qualified option names on `mktemp` (🙄)

We must use `-d` and `-t` on macOS, instead of ``--directory`` and ``--tmpdir``.

**NOTE**: `-t` on macOS is not the same as `-t` on Linux, hence why I didn't just merge the two.